### PR TITLE
feat: restructure project as Python package with uv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv
+
+.coverage
+
+# Session memory
+.puppy_session_memory.json
+
+# Pytest cache
+.pytest_cache/
+
+dummy_path
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# GitDiffViewer
+# Tentacle
 
 A professional Textual-based application for viewing differences between two text files and selectively accepting changes.
+
+## Project Structure
+
+The project is organized as a proper Python package:
+
+- `tentacle/` - Main package directory
+  - `main.py` - Entry point module
+  - `git_diff_viewer.py` - Core application logic
+
+## Development
+
+This project uses `uv` for package management and virtual environment handling. You can run the application directly using `uv run tentacle` command.
+
+To run with Python directly:
+```bash
+python -m tentacle <file1> <file2>
+```
+
 
 ## Features
 
@@ -16,7 +34,13 @@ A professional Textual-based application for viewing differences between two tex
 ## Usage
 
 ```bash
-python app.py <file1> <file2>
+tentacle <file1> <file2>
+```
+
+Or, if running directly with Python:
+
+```bash
+python -m tentacle <file1> <file2>
 ```
 
 ### Controls
@@ -58,10 +82,27 @@ This version features a professional design with:
 pip install textual
 ```
 
-## Example
+Or, if you have `uv` installed:
 
 ```bash
-python app.py sample1.txt sample2.txt
+uv sync
+```
+
+## Example
+
+Using the installed script:
+```bash
+tentacle sample1.txt sample2.txt
+```
+
+Using uv run:
+```bash
+uv run tentacle sample1.txt sample2.txt
+```
+
+Using Python module execution:
+```bash
+python -m tentacle sample1.txt sample2.txt
 ```
 
 The application will display both files side-by-side, with modifications highlighted and accept/reject buttons for each changed line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tentacle"
+version = "0.0.1"
+description = "TUI replacement for GitKraken!"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "textual>=6.1.0",
+]
+
+[project.scripts]
+tentacle = "tentacle.main:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["tentacle"]

--- a/tentacle/git_diff_viewer.py
+++ b/tentacle/git_diff_viewer.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 from difflib import SequenceMatcher
 from textual.app import App, ComposeResult
 from textual.widgets import Static, Header, Footer, Button
@@ -9,7 +8,7 @@ from textual.containers import Horizontal, Vertical, Container
 class GitDiffViewer(App):
     """A Textual app for viewing diffs between two text files in a split-screen UI."""
     
-    CSS_PATH = "style.tcss"
+    CSS_PATH = "../style.tcss"
     BINDINGS = [
         ("q", "quit", "Quit"),
         ("Ctrl+d", "toggle_dark", "Toggle Dark Mode"),
@@ -332,12 +331,7 @@ class GitDiffViewer(App):
             accept_button.add_class("accept-button")
             accept_button.remove_class("accepted-button")
             
-            # Also update reject button if it exists
-            try:
-                reject_button = self.query_one(f"#reject-{line_index}", Button)
-                # No variant update needed as we're not using variants in button creation
-            except:
-                pass
+            # No need to update reject button styling as it doesn't change state
             
     def save_changes(self) -> None:
         """Save accepted changes to file1 and refresh the diff view."""
@@ -386,20 +380,20 @@ class GitDiffViewer(App):
             self.load_files_and_calculate_diff()
             self.refresh_diff_view()
             
+            # Reset accept button styles (reject buttons don't change state)
+            try:
+                buttons = self.query("Button")
+                for button in buttons:
+                    if button.id and button.id.startswith("accept-"):
+                        button.label = "Accept"
+                        button.add_class("accept-button")
+                        button.remove_class("accepted-button")
+            except:
+                # No buttons found
+                pass
+            
             # Show success message
             self.notify("Changes saved successfully to file 1!", severity="information")
             
         except Exception as e:
             self.notify(f"Error saving changes: {e}", severity="error")
-        
-        
-if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: python app.py <file1> <file2>")
-        sys.exit(1)
-        
-    file1_path = sys.argv[1]
-    file2_path = sys.argv[2]
-    
-    app = GitDiffViewer(file1_path, file2_path)
-    app.run()

--- a/tentacle/main.py
+++ b/tentacle/main.py
@@ -1,0 +1,14 @@
+import sys
+
+from tentacle.git_diff_viewer import GitDiffViewer
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python git_diff_viewer.py <file1> <file2>")
+        sys.exit(1)
+
+    file1_path = sys.argv[1]
+    file2_path = sys.argv[2]
+
+    app = GitDiffViewer(file1_path, file2_path)
+    app.run()

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,132 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+plugins = [
+    { name = "mdit-py-plugins" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "tentacle"
+version = "0.0.1"
+source = { editable = "." }
+dependencies = [
+    { name = "textual" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "textual", specifier = ">=6.1.0" }]
+
+[[package]]
+name = "textual"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/44/4b524b2f06e0fa6c4ede56a4e9af5edd5f3f83cf2eea5cb4fd0ce5bbe063/textual-6.1.0.tar.gz", hash = "sha256:cc89826ca2146c645563259320ca4ddc75d183c77afb7d58acdd46849df9144d", size = 1564786, upload-time = "2025-09-02T11:42:34.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/43/f91e041f239b54399310a99041faf33beae9a6e628671471d0fcd6276af4/textual-6.1.0-py3-none-any.whl", hash = "sha256:a3f5e6710404fcdc6385385db894699282dccf2ad50103cebc677403c1baadd5", size = 707840, upload-time = "2025-09-02T11:42:32.746Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
+]


### PR DESCRIPTION
- Convert project from single script to proper Python package structure
- Add pyproject.toml configuration for package management and installation
- Rename app.py to tentacle/git_diff_viewer.py and move entry point to tentacle/main.py
- Add uv.lock file for dependency tracking with uv package manager
- Update README.md with new project structure, usage instructions and development setup
- Configure package to be runnable as module or installed script
- Add comprehensive .gitignore for Python development artifacts